### PR TITLE
Making back button tap visible for video recording

### DIFF
--- a/comp_banner/src/main/res/drawable/back_button.xml
+++ b/comp_banner/src/main/res/drawable/back_button.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <!--The order of these matters - the first matched gets drawn-->
-    <item
-        android:drawable="@drawable/back_button_normal"/>
-
+    <item android:drawable="@drawable/back_button_pressed"
+        android:state_pressed="true" />
+    <item android:drawable="@drawable/back_button_focus"
+        android:state_focused="true" />
+    <item android:drawable="@drawable/back_button_normal" />
 </selector>

--- a/comp_banner/src/main/res/drawable/back_button_focus.xml
+++ b/comp_banner/src/main/res/drawable/back_button_focus.xml
@@ -8,35 +8,35 @@
     <path
         android:strokeColor="#00A99D"
         android:strokeMiterLimit="10"
-        android:pathData="M 5.1 5 H 112.6 V 56.7 H 5.1 V 5 Z" />
+        android:pathData="M 20.7 12.7 H 96.8 V 49.3 H 20.7 V 12.7 Z" />
     <path
         android:fillColor="#2493B5"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="3"
         android:strokeMiterLimit="10"
-        android:pathData="M10.1,57.7h97.5c2.8,0,5-2.3,5-5V11c0-2.8-2.3-5-5-5H10.1c-2.8,0-5,2.3-5,5v41.7C5.1,55.4,7.3,57.7,10.1,57.7z" />
+        android:pathData="M25.7,50h66.1c2.8,0,5-2.3,5-5V18.4c0-2.8-2.3-5-5-5H25.7c-2.8,0-5,2.3-5,5V45C20.7,47.8,23,50,25.7,50z" />
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M79.8,19.7v20c0,0,0.5,2.1-2.5,2.1s-26.7,0-26.7,0l-12-11.1c0,0-1.5-1.7,0-2.7s12.3-10.2,12.3-10.2h27.7
-C78.6,17.8,79.9,17.8,79.8,19.7z" />
+        android:pathData="M73.7,23.1v14.2c0,0,0.4,1.5-1.7,1.5s-18.9,0-18.9,0l-8.5-7.8c0,0-1.1-1.2,0-1.9c1.1-0.7,8.7-7.2,8.7-7.2h19.7
+C72.8,21.8,73.8,21.7,73.7,23.1z" />
     <path
         android:fillColor="#3FA9F5"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="10"
         android:strokeMiterLimit="10"
-        android:pathData="M10.1,56.6h97.5c2.8,0,5-2.3,5-5V10c0-2.8-2.3-5-5-5H10.1c-2.8,0-5,2.3-5,5v41.7C5.1,54.4,7.3,56.6,10.1,56.6z" />
+        android:pathData="M25.7,49.3h66.1c2.8,0,5-2.3,5-5V17.7c0-2.8-2.3-5-5-5H25.7c-2.8,0-5,2.3-5,5v26.6C20.7,47,23,49.3,25.7,49.3z" />
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M79.8,19.7v20c0,0,0.5,2.1-2.5,2.1s-26.7,0-26.7,0l-12-11.1c0,0-1.5-1.7,0-2.7s12.3-10.2,12.3-10.2h27.7
-C78.6,17.8,79.9,17.9,79.8,19.7z" />
+        android:pathData="M73.8,23.1v14.2c0,0,0.3,1.6-1.9,1.6s-18.9,0-18.9,0l-8.5-7.9c0,0-1.1-1.2,0-1.9c1.1-0.7,8.7-7.2,8.7-7.2h19.7
+C72.8,21.8,73.8,21.8,73.8,23.1z" />
     <path
-        android:fillColor="#26ADE4"
+        android:fillColor="#F4B350"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="3"
         android:strokeMiterLimit="10"
-        android:pathData="M10.1,56.6h97.5c2.8,0,5-2.3,5-5V10c0-2.8-2.3-5-5-5H10.1c-2.8,0-5,2.3-5,5v41.7C5.1,54.4,7.3,56.6,10.1,56.6z" />
+        android:pathData="M25.7,49.3h66.1c2.8,0,5-2.3,5-5V17.7c0-2.8-2.3-5-5-5H25.7c-2.8,0-5,2.3-5,5v26.6C20.7,47,23,49.3,25.7,49.3z" />
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M79.8,19.7v20c0,0,0.5,2.1-2.5,2.1s-26.7,0-26.7,0l-12-11.1c0,0-1.5-1.7,0-2.7s12.3-10.2,12.3-10.2h27.7
-C78.6,17.8,79.8,16.7,79.8,19.7z" />
+        android:pathData="M73.8,23.1v14.2c0,0,0.3,1.6-1.9,1.6s-18.9,0-18.9,0l-8.5-7.9c0,0-1.1-1.2,0-1.9c1.1-0.7,8.7-7.2,8.7-7.2h19.7
+C72.8,21.8,73.8,21.8,73.8,23.1z" />
 </vector>

--- a/comp_banner/src/main/res/drawable/back_button_normal.xml
+++ b/comp_banner/src/main/res/drawable/back_button_normal.xml
@@ -8,35 +8,35 @@
     <path
         android:strokeColor="#00A99D"
         android:strokeMiterLimit="10"
-        android:pathData="M 20.7 12.7 H 96.8 V 49.3 H 20.7 V 12.7 Z" />
+        android:pathData="M 5.1 5 H 112.6 V 56.7 H 5.1 V 5 Z" />
     <path
         android:fillColor="#2493B5"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="3"
         android:strokeMiterLimit="10"
-        android:pathData="M25.7,50h66.1c2.8,0,5-2.3,5-5V18.4c0-2.8-2.3-5-5-5H25.7c-2.8,0-5,2.3-5,5V45C20.7,47.8,23,50,25.7,50z" />
+        android:pathData="M10.1,57.7h97.5c2.8,0,5-2.3,5-5V11c0-2.8-2.3-5-5-5H10.1c-2.8,0-5,2.3-5,5v41.7C5.1,55.4,7.3,57.7,10.1,57.7z" />
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M73.7,23.1v14.2c0,0,0.4,1.5-1.7,1.5s-18.9,0-18.9,0l-8.5-7.8c0,0-1.1-1.2,0-1.9c1.1-0.7,8.7-7.2,8.7-7.2h19.7
-C72.8,21.8,73.8,21.7,73.7,23.1z" />
+        android:pathData="M79.8,19.7v20c0,0,0.5,2.1-2.5,2.1s-26.7,0-26.7,0l-12-11.1c0,0-1.5-1.7,0-2.7s12.3-10.2,12.3-10.2h27.7
+C78.6,17.8,79.9,17.8,79.8,19.7z" />
     <path
         android:fillColor="#3FA9F5"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="10"
         android:strokeMiterLimit="10"
-        android:pathData="M25.7,49.3h66.1c2.8,0,5-2.3,5-5V17.7c0-2.8-2.3-5-5-5H25.7c-2.8,0-5,2.3-5,5v26.6C20.7,47,23,49.3,25.7,49.3z" />
+        android:pathData="M10.1,56.6h97.5c2.8,0,5-2.3,5-5V10c0-2.8-2.3-5-5-5H10.1c-2.8,0-5,2.3-5,5v41.7C5.1,54.4,7.3,56.6,10.1,56.6z" />
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M73.8,23.1v14.2c0,0,0.3,1.6-1.9,1.6s-18.9,0-18.9,0l-8.5-7.9c0,0-1.1-1.2,0-1.9c1.1-0.7,8.7-7.2,8.7-7.2h19.7
-C72.8,21.8,73.8,21.8,73.8,23.1z" />
+        android:pathData="M79.8,19.7v20c0,0,0.5,2.1-2.5,2.1s-26.7,0-26.7,0l-12-11.1c0,0-1.5-1.7,0-2.7s12.3-10.2,12.3-10.2h27.7
+C78.6,17.8,79.9,17.9,79.8,19.7z" />
     <path
         android:fillColor="#26ADE4"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="3"
         android:strokeMiterLimit="10"
-        android:pathData="M25.7,49.3h66.1c2.8,0,5-2.3,5-5V17.7c0-2.8-2.3-5-5-5H25.7c-2.8,0-5,2.3-5,5v26.6C20.7,47,23,49.3,25.7,49.3z" />
+        android:pathData="M10.1,56.6h97.5c2.8,0,5-2.3,5-5V10c0-2.8-2.3-5-5-5H10.1c-2.8,0-5,2.3-5,5v41.7C5.1,54.4,7.3,56.6,10.1,56.6z" />
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M73.8,23.1v14.2c0,0,0.3,1.6-1.9,1.6s-18.9,0-18.9,0l-8.5-7.9c0,0-1.1-1.2,0-1.9c1.1-0.7,8.7-7.2,8.7-7.2h19.7
-C72.8,21.8,73.8,21.8,73.8,23.1z" />
+        android:pathData="M79.8,19.7v20c0,0,0.5,2.1-2.5,2.1s-26.7,0-26.7,0l-12-11.1c0,0-1.5-1.7,0-2.7s12.3-10.2,12.3-10.2h27.7
+C78.6,17.8,79.8,16.7,79.8,19.7z" />
 </vector>

--- a/comp_banner/src/main/res/drawable/back_button_pressed.xml
+++ b/comp_banner/src/main/res/drawable/back_button_pressed.xml
@@ -8,35 +8,35 @@
     <path
         android:strokeColor="#00A99D"
         android:strokeMiterLimit="10"
-        android:pathData="M 5.1 5 H 112.6 V 56.7 H 5.1 V 5 Z" />
+        android:pathData="M 20.7 12.7 H 96.8 V 49.3 H 20.7 V 12.7 Z" />
     <path
         android:fillColor="#2493B5"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="3"
         android:strokeMiterLimit="10"
-        android:pathData="M10.1,57.7h97.5c2.8,0,5-2.3,5-5V11c0-2.8-2.3-5-5-5H10.1c-2.8,0-5,2.3-5,5v41.7C5.1,55.4,7.3,57.7,10.1,57.7z" />
+        android:pathData="M25.7,50h66.1c2.8,0,5-2.3,5-5V18.4c0-2.8-2.3-5-5-5H25.7c-2.8,0-5,2.3-5,5V45C20.7,47.8,23,50,25.7,50z" />
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M79.8,19.7v20c0,0,0.5,2.1-2.5,2.1s-26.7,0-26.7,0l-12-11.1c0,0-1.5-1.7,0-2.7s12.3-10.2,12.3-10.2h27.7
-C78.6,17.8,79.9,17.8,79.8,19.7z" />
+        android:pathData="M73.7,23.1v14.2c0,0,0.4,1.5-1.7,1.5s-18.9,0-18.9,0l-8.5-7.8c0,0-1.1-1.2,0-1.9c1.1-0.7,8.7-7.2,8.7-7.2h19.7
+C72.8,21.8,73.8,21.7,73.7,23.1z" />
     <path
         android:fillColor="#3FA9F5"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="10"
         android:strokeMiterLimit="10"
-        android:pathData="M10.1,56.6h97.5c2.8,0,5-2.3,5-5V10c0-2.8-2.3-5-5-5H10.1c-2.8,0-5,2.3-5,5v41.7C5.1,54.4,7.3,56.6,10.1,56.6z" />
+        android:pathData="M25.7,49.3h66.1c2.8,0,5-2.3,5-5V17.7c0-2.8-2.3-5-5-5H25.7c-2.8,0-5,2.3-5,5v26.6C20.7,47,23,49.3,25.7,49.3z" />
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M79.8,19.7v20c0,0,0.5,2.1-2.5,2.1s-26.7,0-26.7,0l-12-11.1c0,0-1.5-1.7,0-2.7s12.3-10.2,12.3-10.2h27.7
-C78.6,17.8,79.8,16.7,79.8,19.7z" />
+        android:pathData="M73.8,23.1v14.2c0,0,0.3,1.6-1.9,1.6s-18.9,0-18.9,0l-8.5-7.9c0,0-1.1-1.2,0-1.9c1.1-0.7,8.7-7.2,8.7-7.2h19.7
+C72.8,21.8,73.8,21.8,73.8,23.1z" />
     <path
-        android:fillColor="#26ADE4"
+        android:fillColor="#F4B350"
         android:strokeColor="#FFFFFF"
         android:strokeWidth="3"
         android:strokeMiterLimit="10"
-        android:pathData="M10.1,56.6h97.5c2.8,0,5-2.3,5-5V10c0-2.8-2.3-5-5-5H10.1c-2.8,0-5,2.3-5,5v41.7C5.1,54.4,7.3,56.6,10.1,56.6z" />
+        android:pathData="M25.7,49.3h66.1c2.8,0,5-2.3,5-5V17.7c0-2.8-2.3-5-5-5H25.7c-2.8,0-5,2.3-5,5v26.6C20.7,47,23,49.3,25.7,49.3z" />
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M79.8,19.7v20c0,0,0.5,2.1-2.5,2.1s-26.7,0-26.7,0l-12-11.1c0,0-1.5-1.7,0-2.7s12.3-10.2,12.3-10.2h27.7
-C78.6,17.8,79.8,16.7,79.8,19.7z" />
+        android:pathData="M73.8,23.1v14.2c0,0,0.3,1.6-1.9,1.6s-18.9,0-18.9,0l-8.5-7.9c0,0-1.1-1.2,0-1.9c1.1-0.7,8.7-7.2,8.7-7.2h19.7
+C72.8,21.8,73.8,21.8,73.8,23.1z" />
 </vector>


### PR DESCRIPTION
This makes the usual size of the back button slightly bigger, and makes it smaller and orange on the tapping. Tested on AZ screen recorder, gives a proper indication of a back button press. Related to #349 