### PR TITLE
Number Log Files

### DIFF
--- a/app/src/main/java/cmu/xprize/robotutor/RoboTutor.java
+++ b/app/src/main/java/cmu/xprize/robotutor/RoboTutor.java
@@ -164,7 +164,7 @@ public class RoboTutor extends Activity implements IReadyListener, IRoboTutor {
         String initTime     = new SimpleDateFormat("yyyy.MM.dd.HH.mm.ss", Locale.US).format(calendar.getTime());
         String sequenceIdString = String.format(Locale.US, "%04d", getNextLogSequenceId());
         // NOTE: Need to include the configuration name when that is fully merged
-        String logFilename  = "RoboTutor_" + BuildConfig.VERSION_NAME + Build.SERIAL + sequenceIdString + "_" + initTime;
+        String logFilename  = "RoboTutor_" + BuildConfig.BUILD_TYPE + "." + BuildConfig.VERSION_NAME + "_" + initTime + "_" + Build.SERIAL + "_" + sequenceIdString;
 
         Log.d(TCONST.DEBUG_GRAY_SCREEN_TAG, "rt: onCreate");
         // Catch all errors and cause a clean exit -


### PR DESCRIPTION
Address Issue #366 

NOTE: this will need to be updated with configuration items, when available

 * create a sequence ID to be appended onto the log files to assist
   in recreating the log sequence when the device loses power and
   sets the time to the year 2000
 * the sequence ID is created at first run in the SharedPreferences,
   and each time it is accessed (when the app launches) it is incremented
   by 1
 * update the ordering of the log file name to make it easier to
   reconstruct the sequence of events